### PR TITLE
Improved error handling for testing infrastructure

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -30,6 +30,7 @@ def docker_client():
 def database_url(docker_client):
     """Creates a testing database using an enviornment-provided connection string or by spinning up a Docker container."""
     testing_db = environ.get("TESTING_DATABASE")
+    image = environ.get("POSTGRES_IMAGE", "postgis/postgis:14-3.3")
 
     # Check if testing_db is accessible
     if testing_db is not None:
@@ -44,9 +45,7 @@ def database_url(docker_client):
     elif docker_client is not None:
         port = get_unused_port()
 
-        with database_cluster(
-            docker_client, "postgis/postgis:14-3.3", None, port=port
-        ) as container:
+        with database_cluster(docker_client, image, None, port=port) as container:
             # Connect to cluster
             url = f"postgresql://postgres@localhost:{port}/postgres"
             yield url


### PR DESCRIPTION
Small fixes to allow more consistent testing across platforms.
- Timeout for database connection (defaults to 30 seconds)
- Half-second timeout on database cluster establishment to ensure stability
- Allow `POSTGRES_IMAGE` to be specified as an environment variable for testing