### PR TITLE
Fix wait callback bug

### DIFF
--- a/database/macrostrat/database/postgresql.py
+++ b/database/macrostrat/database/postgresql.py
@@ -60,20 +60,6 @@ def prefix_inserts(insert, compiler, **kw):
     return compiler.visit_insert(insert, **kw)
 
 
-_psycopg2_setup_was_run = ContextVar("psycopg2-setup-was-run", default=False)
-
-
-def _setup_psycopg2_wait_callback():
-    """Set up the wait callback for PostgreSQL connections. This allows for query cancellation with Ctrl-C."""
-    # TODO: we might want to do this only once on engine creation
-    # https://github.com/psycopg/psycopg2/issues/333
-    val = _psycopg2_setup_was_run.get()
-    if val:
-        return
-    psycopg2.extensions.set_wait_callback(psycopg2.extras.wait_select)
-    _psycopg2_setup_was_run.set(True)
-
-
 def table_exists(db: Database, table_name: str, schema: str = "public") -> bool:
     """Check if a table exists in a PostgreSQL database."""
     sql = """SELECT EXISTS (

--- a/database/pyproject.toml
+++ b/database/pyproject.toml
@@ -3,7 +3,7 @@ authors = ["Daven Quinn <dev@davenquinn.com>"]
 description = "A SQLAlchemy-based database toolkit."
 name = "macrostrat.database"
 packages = [{ include = "macrostrat" }]
-version = "3.1.1"
+version = "3.1.2"
 
 [tool.poetry.dependencies]
 GeoAlchemy2 = "^0.14.0"

--- a/database/test_database.py
+++ b/database/test_database.py
@@ -5,6 +5,7 @@ NOTE: At the moment, these tests are not independent and must run in order.
 """
 
 from pathlib import Path
+from sys import stdout
 
 from dotenv import load_dotenv
 from psycopg2.errors import SyntaxError
@@ -286,6 +287,13 @@ def test_ambiguous_comment_bind(db):
     res = db.run_query(sql, dict(name=Literal("Test")))
     data = res.scalar()
     assert data == "Test"
+
+
+def test_copy_statement(db):
+    pg_conn = db.engine.connect().connection
+    cur = pg_conn.cursor()
+
+    cur.copy_expert("COPY sample (name) TO STDOUT", stdout)
 
 
 def test_close_connection(conn):


### PR DESCRIPTION
This fixes a bug where the PsycoPG2 `wait_select` callback outlives
a `run_sql` call and interferes with later use of a database connection
by other modules. It should fix UW-Macrostrat/macrostrat#30. 

- Created a failing test
- Scope wait_select callback to a single run_sql call. Fixes #29
- Increment version number of database module
